### PR TITLE
Fix to make it build with ghc 7.8.x

### DIFF
--- a/System/Hclip.hs
+++ b/System/Hclip.hs
@@ -154,6 +154,7 @@ execute Windows (SetClipboard s) =
 resolveLinuxApp :: Command a -> IO String
 resolveLinuxApp cmd = decode cmd <$> chooseFirstApp ["xsel", "xclip"] 
     where
+        decode :: Command a -> String -> String
         decode GetClipboard "xsel"      = "xsel -o"
         decode (SetClipboard _) "xsel"  = "xsel -i"
         decode GetClipboard "xclip"     = "xclip -selection c -o"


### PR DESCRIPTION
GHC 7.8 can no longer infer the type of the `decode` function used in `resolveLinuxApp`, so an annotation is required.
